### PR TITLE
#28 = Don't load assets on _draw method

### DIFF
--- a/src/objects/avatars/Avatar.ts
+++ b/src/objects/avatars/Avatar.ts
@@ -35,6 +35,8 @@ export class Avatar extends RoomObject {
 
     private _bodyParts: AvatarBodyPart[] = [];
 
+    private areAllAssetsLoaded: boolean = false;
+
     constructor(
         configuration: IAvatarConfiguration
     ) {
@@ -46,6 +48,12 @@ export class Avatar extends RoomObject {
         this._bodyDirection = configuration.bodyDirection;
         this._actions = configuration.actions;
         this._handItem = configuration.handItem;
+        let assets = [];
+
+        if(this._handItem !== 0 || this._handItem !== undefined) {
+            assets.push(AssetLoader.load("figures/hh_human_item", "figure/hh_human_item/hh_human_item.json"));
+        }
+        assets.push(AssetLoader.load("figures/hh_human_body", "figure/hh_human_body/hh_human_body.json"));
 
         this._actionManager = new AvatarActionManager(AvatarAction.Default);
         this._animationManager = new AvatarAnimationManager();
@@ -62,14 +70,24 @@ export class Avatar extends RoomObject {
             }));
         });
         //this.interactive = true;
+
+        Promise.all(assets).then(() => {
+            this.areAllAssetsLoaded = true;
+        });
     }
 
     private _draw(): void {
         this._destroyParts();
-        if(this._handItem !== 0 || this._handItem !== undefined) {
-            AssetLoader.load("figures/hh_human_item", "figure/hh_human_item/hh_human_item.json").then(() => this._createHandItem(this._handItem));
+
+        if (!this.areAllAssetsLoaded) {
+            return;
         }
-        AssetLoader.load("figures/hh_human_body", "figure/hh_human_body/hh_human_body.json").then(() => this._createShadow());
+
+        if(this._handItem !== 0 || this._handItem !== undefined) {
+            this._createHandItem(this._handItem);
+        }
+        this._createShadow();
+
         this._bodyParts.forEach((bodyPart: AvatarBodyPart) => bodyPart.updateParts());
 
         this.x = 32 * this._position.x - 32 * this._position.y;

--- a/src/objects/avatars/AvatarBodyPart.ts
+++ b/src/objects/avatars/AvatarBodyPart.ts
@@ -23,6 +23,8 @@ export class AvatarBodyPart {
 
     private _frames: Map<number, Map<string, { action: AvatarAction, frame: number, repeat: number }>> = new Map();
 
+    private areAllAssetsLoaded: boolean = false;
+
     constructor(
         avatar: Avatar,
         configuration: IBodyPartConfiguration
@@ -33,11 +35,23 @@ export class AvatarBodyPart {
         this._colors = configuration.colors;
         this._parts = configuration.parts;
         this._actions = configuration.actions;
+        let assets : Promise<void>[] = [];
+
+        this._parts.forEach((part: IAvatarPart) => {
+            assets.push(AssetLoader.load("figures/" + part.lib.id, "figure/" + part.lib.id + "/" + part.lib.id + ".json"));
+        });
+
+        Promise.all(assets).then(() => {
+            this.areAllAssetsLoaded = true;
+        });
     }
 
     private _draw(): void {
+        if (!this.areAllAssetsLoaded) {
+            return;
+        }
         this._parts.forEach((part: IAvatarPart) => {
-            AssetLoader.load("figures/" + part.lib.id, "figure/" + part.lib.id + "/" + part.lib.id + ".json").then(() => this._createPart(part));
+            this._createPart(part);
         });
     }
 


### PR DESCRIPTION
Mostly closes #28

Avatar related assets were being loaded on _draw function, which is a terrible idea as it's fired every frame. 
That's why scenes with avatars went to <2fps for several seconds when loading.

The amount of warnings went from 78k to 5k. The performance improvement is noticeable, so we should take a look at the remaining warnings.
There are still warnings because, for some reason, each body part is requesting assets that all other parts are also requesting:
![image](https://user-images.githubusercontent.com/1708730/230731582-55568a5c-705f-4a12-b019-d7964fd96195.png)




