### PR TITLE
= AssetLoader - Prevent condition races

### DIFF
--- a/src/utilities/AssetLoader.ts
+++ b/src/utilities/AssetLoader.ts
@@ -1,14 +1,24 @@
-import { Assets } from 'pixi.js';
+import { Assets, Cache } from 'pixi.js';
 
 const domain = 'http://localhost:8081/';
 
+interface LoadedKeys {
+  [key: string]: Promise<any>;
+}
+const loadedKeys: LoadedKeys = {};
+
 const load = async (key: string, url: string, onUncached?: () => void): Promise<void> => {
-  if (Assets.get(key) === undefined) {
+  if (typeof loadedKeys[key] !== "undefined") {
+    await loadedKeys[key];
+    return;
+  }
+  if (!Cache.has(key)) {
     if (onUncached != null) {
       onUncached();
     }
     Assets.add(key, AssetLoader.domain + url);
-    await Assets.load(key);
+    loadedKeys[key] = Assets.load(key);
+    await loadedKeys[key];
   }
 };
 


### PR DESCRIPTION
While Pixi's Assets class is loading an asset it won't set it as loaded, so if the same asset is requested several times at the same time (like furniture and body parts do), it will accept all and then cry because it's loaded.

All i can think to prevent it this is dictionary. 
After this PR there are 0 cache warnings.